### PR TITLE
Fix the issue of difficult to see inline prediction clearly in Windows Terminal

### DIFF
--- a/theme/dracula-prompt-configuration.ps1
+++ b/theme/dracula-prompt-configuration.ps1
@@ -8,6 +8,7 @@ Set-PSReadlineOption -Color @{
     "Number" = [ConsoleColor]::Blue
     "Type" = [ConsoleColor]::Cyan
     "Comment" = [ConsoleColor]::DarkCyan
+    "InlinePrediction" = [ConsoleColor]::DarkGray
 }
 # Dracula Prompt Configuration
 Import-Module posh-git


### PR DESCRIPTION
The origin theme works well in Powershell. But in **_Windows Terminal_**, the inline prediction nearly integrate with the background:

![Snipaste_2023-04-04_14-40-54](https://user-images.githubusercontent.com/101185502/229709696-7d49204e-cc4f-45b2-acf7-48deb9e4544d.png)

After adding `"InlinePrediction" = [ConsoleColor]::DarkGray`:

![Snipaste_2023-04-04_14-40-33](https://user-images.githubusercontent.com/101185502/229709691-893463fa-c38c-4009-8c28-8dac59b55954.png)

No changes to display in Powershell:

![image](https://user-images.githubusercontent.com/101185502/229711802-85b47fc3-980d-478f-b1c7-c0670ed6c4ab.png)

![image](https://user-images.githubusercontent.com/101185502/229711949-17d4d9dc-2970-4360-b112-3f5bc8983f69.png)

---

Maybe the color `DarkGray` was not designed to display it, but I didn't find another color more suitable. And it actually did improve my reading experience.